### PR TITLE
Add --no-gui headless mode and related GUI safety fixes

### DIFF
--- a/src/gui_manager.h
+++ b/src/gui_manager.h
@@ -9,7 +9,6 @@
 
 // Forward-declare Metal types for macOS
 #if defined(__APPLE__)
-typedef void* id; // C++ compatible forward declaration for Objective-C objects
 #endif
 
 namespace atem {


### PR DESCRIPTION
This PR adds a --no-gui command-line flag to allow running the server in headless mode (useful for servers or CI). When --no-gui is provided the program skips GUI initialization and runs the Boost.Asio [io_context](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) on the main thread so the process remains alive.